### PR TITLE
cakeSize & candles values, able to transfer from cake_template to cakes_cart page

### DIFF
--- a/cake_template.html
+++ b/cake_template.html
@@ -323,17 +323,17 @@
           <!--1st option-->
         <div class="consumer_radioBtn">
           <div class="form-check my-3 ">
-            <input type="radio" id="six_inch" name="cake-size" value= '6'  unchecked>  <!--name for 3 radio buttons need to be the same in order for no double selection-->
+            <input type="radio" id="six_inch" name="cakeSize" value= '6'  unchecked>  <!--name for 3 radio buttons need to be the same in order for no double selection-->
             <label class='form-check-label'>6" inch</label>
           </div>
           <!--2nd option-->
           <div class="form-check my-3">
-            <input type="radio" id="eight_inch" name="cake-size" value= '8' unchecked>  <!--The value is different but the name remains the same because they are both options for the first qns-->
+            <input type="radio" id="eight_inch" name="cakeSize" value= '8' unchecked>  <!--The value is different but the name remains the same because they are both options for the first qns-->
             <label class='form-check-label'>8" inch</label>
           </div>
           <!--3rd option-->
           <div class="form-check mb-3">
-            <input type="radio" id="ten_inch" name="cake-size" value= '10' unchecked>  <!--The value is different but the name remains the same because they are both options for the first qns-->
+            <input type="radio" id="ten_inch" name="cakeSize" value= '10' unchecked>  <!--The value is different but the name remains the same because they are both options for the first qns-->
             <label class='form-check-label'>10" inch</label>
           </div>
         </div>
@@ -345,12 +345,12 @@
         <!-- <form class="Candle:"> -->
           <!--1st option-->
           <div class="form-check mb-3">
-            <input type="number" id="candlesQuantity" name="quantity" min="0" max="10" value='0' placeholder="0">
+            <input type="number" id="candlesQuantity" name="candles" min="0" max="10" value='0' placeholder="0">
           </div>
         <!-- </form> -->
 
         <div class='text-left my-5'>
-          <button type="submit" class="btn btn-success">Submit</button> 
+          <button type="submit" class="btn btn-success" onclick="sentToLocal()">Submit</button> 
        </div>
       </form>                     <!--End of form-->
 

--- a/cakes_cart.html
+++ b/cakes_cart.html
@@ -235,15 +235,15 @@
 
   <!----------------------------------------------------------(Start)FORM---------------------------------------------------->
   <div class="container bg-white py-2 my-5">
-    <div id="cart" class="bg-white"></div>
+    <div id="cart"></div>
 
     <!------------------------------------------------------------(End)FORM---------------------------------------------------->
 
     <!-----------------------------------------------------(start)CART TOTAL--------------------------------------------------->
-    <div class="row mt-5 bg-white">
+    <div class="row mt-5">
       <label class="col-sm-3 text-center control-label"><strong>Cart Total</strong></label>
-      <div class="col-md-5 offset-md-4 col-sm-7 offset-sm-2 bg-white">
-        <table class="table table-totals bg-white">
+      <div class="col-md-5 offset-md-4 col-sm-7 offset-sm-2">
+        <table class="table table-totals">
           <tbody>
             <tr>
               <td class="text-left"><strong>Sub-Total:</strong></td>

--- a/js/cake_template.js
+++ b/js/cake_template.js
@@ -1,3 +1,11 @@
+// Global variables
+var globPname;
+var globDesc;
+var globPrice;
+var globImage;
+var globCakeSize;
+var globCandles;
+
 function load() {
     var urlParams = new URLSearchParams(window.location.search);
     var image = "<img src = "+'"'+urlParams.get('img')+'">';
@@ -10,62 +18,87 @@ function load() {
 
 document.onload = load();
 
+function sentToLocal() {
+    var urlParams = new URLSearchParams(window.location.search);
+    globPname = urlParams.get('name');
+    globDesc = urlParams.get('desc');
+    globPrice = urlParams.get('price');
+    globImage = urlParams.get('img');
+    globCakeSize = document.querySelector('[name="cakeSize"]:checked').value;
+    globCandles = document.querySelector('[name="candles"]').value;
+        
+    let myCakeProducts = [
+        {
+        productId: 1,
+        productName: globPname,
+        description: globDesc,
+        price: globPrice,
+        cakesQuantity: 1,
+        cakeSize: globCakeSize,
+        candles: globCandles,
+        imageUrl: globImage
+        }];
+  
+    localStorage.setItem("cakesData",JSON.stringify(myCakeProducts));
+}
+  
+// ======================================================================================
 // Parsing Form to CHECKOUT CART (START)
-const consumerForm = document.querySelector('.consumer_selection'); 
-console.log(consumerForm);
-const consumerFormRadio = document.querySelectorAll('.consumer_radioBtn > div > input'); //Nodelist(3)
-console.log(consumerFormRadio);
-const sixInch = document.querySelector('#six_inch');
-console.log(sixInch.value);
-// console.log(sixInch);
-const eightInch = document.querySelector('#eight_inch');
-// console.log(eightInch);
-const tenInch = document.querySelector('#ten_inch');
-// console.log(tenInch);
-const noOfCandles = document.querySelector('#candlesQuantity');
-// console.log(noOfCandles.value);
+// const consumerForm = document.querySelector('.consumer_selection'); 
+// console.log(consumerForm);
+// const consumerFormRadio = document.querySelectorAll('.consumer_radioBtn > div > input'); //Nodelist(3)
+// console.log(consumerFormRadio);
+// const sixInch = document.querySelector('#six_inch');
+// console.log(sixInch.value);
+// // console.log(sixInch);
+// const eightInch = document.querySelector('#eight_inch');
+// // console.log(eightInch);
+// const tenInch = document.querySelector('#ten_inch');
+// // console.log(tenInch);
+// const noOfCandles = document.querySelector('#candlesQuantity');
+// // console.log(noOfCandles.value);
 
 
-const sample = document.querySelectorAll('.consumer_radioBtn > div > input');
-console.log(sample);
-var prev = null;
-sample.forEach(element => {
-   if(sixInch.checked)     
-});
+// const sample = document.querySelectorAll('.consumer_radioBtn > div > input');
+// console.log(sample);
+// var prev = null;
+// sample.forEach(element => {
+//    if(sixInch.checked)     
+// });
 
 
-consumerForm.addEventListener('submit', function(e){
+// consumerForm.addEventListener('submit', function(e){
 
-    e.preventDefault();
-    console.log(e.target); //consumerForm
+//     e.preventDefault();
+//     console.log(e.target); //consumerForm
 
-    if(sixInch.checked == true){
-        // alert(sixInch.value +'" inch cake selected');
-        //if(noOfCandles.value <= 0){
-            //Prompt user to check whether they want any candle
-            //alert('Will you like to include any candles? If not, press submit to continue.');
-            //    if(noOfCandles >= 0){
-            window.location = "cakes_cart.html";
+//     if(sixInch.checked == true){
+//         // alert(sixInch.value +'" inch cake selected');
+//         //if(noOfCandles.value <= 0){
+//             //Prompt user to check whether they want any candle
+//             //alert('Will you like to include any candles? If not, press submit to continue.');
+//             //    if(noOfCandles >= 0){
+//             window.location = "cakes_cart.html";
             
-    }else if(eightInch.checked == true){
-        // alert(eightInch.value + '" inch cake selected');
-        //if(noOfCandles.value < 1){
-            //Prompt user to check whether they want any candle
-            //alert('Will you like to include any candles? If not, press submit to continue.');
-            window.location = "cakes_cart.html";
+//     }else if(eightInch.checked == true){
+//         // alert(eightInch.value + '" inch cake selected');
+//         //if(noOfCandles.value < 1){
+//             //Prompt user to check whether they want any candle
+//             //alert('Will you like to include any candles? If not, press submit to continue.');
+//             window.location = "cakes_cart.html";
             
-    }else if(tenInch.checked == true){
-        // alert(tenInch.value + '" inch cake selected');
-        //if(noOfCandles.value < 1){
-            //Prompt user to check whether they want any candle
-            //alert('Will you like to include any candles? If not, press submit to continue.');
-            //}else{
-                window.location = "cakes_cart.html";
-            //}
-    }else{
-        alert('Please indicate the size selection.');
-    } 
+//     }else if(tenInch.checked == true){
+//         // alert(tenInch.value + '" inch cake selected');
+//         //if(noOfCandles.value < 1){
+//             //Prompt user to check whether they want any candle
+//             //alert('Will you like to include any candles? If not, press submit to continue.');
+//             //}else{
+//                 window.location = "cakes_cart.html";
+//             //}
+//     }else{
+//         alert('Please indicate the size selection.');
+//     } 
 
-})
+// })
 // Parsing Form to CHECKOUT CART (END)
 

--- a/js/cakes_cart.js
+++ b/js/cakes_cart.js
@@ -4,7 +4,7 @@ function trashCake(cakeId) {
   localStorage.setItem("cakesData",JSON.stringify(storedCakesData));
 
   // For development purpose only, set flag to false, to prevent full reload of all cakes
-  sessionStorage.setItem("canReloadAllCakesAgain","false");
+  // sessionStorage.setItem("canReloadAllCakesAgain","false");
 
   window.location.href = "cakes_cart.html";
 }
@@ -17,7 +17,7 @@ var totalCost = 0.0; // customer will pay this final amount, to pass to cakes_ca
 var gst = 0.0;
 
 // For development purpose only, set flag to false, to prevent full reload of all cakes
-sessionStorage.setItem("canReloadAllCakesAgain","false");
+// sessionStorage.setItem("canReloadAllCakesAgain","false");
 
 sessionStorage.setItem("totalCost",JSON.stringify(totalCost));
 sessionStorage.setItem("gst",JSON.stringify(gst));

--- a/js/cakes_checkout.js
+++ b/js/cakes_checkout.js
@@ -1,2 +1,3 @@
-sessionStorage.clear();
-localStorage.clear();
+sessionStorage.removeItem('gst');
+sessionStorage.removeItem('totalCost');
+localStorage.removeItem('cakesData');

--- a/js/main_page.js
+++ b/js/main_page.js
@@ -98,4 +98,4 @@
   // For cakes_cart trash purpose, set flag to true initially, to load all cakes to localstorage.
   // When customer delete a cake from cakes_cart page, set flag to false
   // to prevent full reload of all cakes in cakes_cart page.
-  sessionStorage.setItem("canReloadAllCakesAgain","true");
+  // sessionStorage.setItem("canReloadAllCakesAgain","true");


### PR DESCRIPTION
cakeSize & candles values can transfer from cake_template to cakes_cart page, 
removed testing setup of pre-loading all 10 cakes into localStorage in main_page.js & cakes_cart.js, 
added specific clearing of local&session storage data after customer checkout purchase.
Presently only able to add 1 cake to cakes_cart page, to add logic to allow additional cakes to be added to cakes_cart page for checkout.
Just forked from cornsarebanned, then added my changes, & pushed here again.